### PR TITLE
hotfix/change-linked-firefox-extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ presented by sunbathr and rawbeee
 A suite of scripts intended to enhance the neoboard experience on desktop
 
 # how to use
-* Install <a href="https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en">Tampermonkey</a> (Chrome) or <a href="https://addons.mozilla.org/en-CA/firefox/addon/greasemonkey/"> Greasemonkey</a> (Firefox).
+* Install Tampermonkey ([Chrome](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/)).
 * Navigate to the script(s) you would like to install.
-  * <a href="https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/enhanced-neoboard-actions.user.js">enhanced-neoboard-actions.user.js</a>
-  * <a href="https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/enhanced-neoboard-smilies.user.js">enhanced-neoboard-smilies.user.js</a>
-  * <a href="https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/neoboard-bookmarks.user.js">neoboard-bookmarks.user.js</a>
-  * <a href="https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/neoboard-follow-users.user.js">neoboard-follow-users.user.js</a>
+  * [enhanced-neoboard-actions.user.js](https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/enhanced-neoboard-actions.user.js)
+  * [enhanced-neoboard-smilies.user.js](https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/enhanced-neoboard-smilies.user.js)
+  * [neoboard-bookmarks.user.js](https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/neoboard-bookmarks.user.js)
+  * [neoboard-follow-users.user.js](https://github.com/rawxbee/neoboard-enhancement-suite/blob/main/neoboard-follow-users.user.js)
 * On the script page locate the button labelled "Raw" and click it.
 * A new tab should open that will give you the choice to review the code and install.
   * As long as you do not edit the script yourself, you should be notified when an update is available and be given the option to update. You may also choose to update/reinstall by repeating the steps above.
@@ -18,11 +18,11 @@ A suite of scripts intended to enhance the neoboard experience on desktop
 # the settings cog
 * No matter what combination of scripts you install, while you are on the neoboards a settings cog will appear on the left side of the bar that includes your neopoints/etc. 
 
-* <img src="https://i.imgur.com/yIXEtmx.png">
+* ![](https://i.imgur.com/yIXEtmx.png)
 
 * This menu will give you quick access to the neoboard index, neoboard preferences and the neoboard-enhancement-suite.
 
-* <img src="https://i.imgur.com/zDgByKU.png">
+* ![](https://i.imgur.com/zDgByKU.png)
 
 * If an installed script has settings associated with it, those options will populate the menu.
 
@@ -35,11 +35,11 @@ A suite of scripts intended to enhance the neoboard experience on desktop
 
 * Adds a refresh button to each reply and restyles the report button.
 
-* <img src="https://i.imgur.com/l8tZf34.png" style="border: 1px solid #cacaca;">
+* ![](https://i.imgur.com/l8tZf34.png)
 
 * For those who use neoboard pens, you will have the choice to set a pen to be remembered (the next pen you click will be remembered and autoselected across the neoboards) or to set your pens to random (each page refresh will randomly select a pen).
 
-* <img src="https://i.imgur.com/QHGBm5k.png">
+* ![](https://i.imgur.com/QHGBm5k.png)
 
 * Links to DTI closets or outfits will be embedded as clickable links
 
@@ -50,17 +50,17 @@ A suite of scripts intended to enhance the neoboard experience on desktop
 
 * An empty character is available within general smilie category (the plus icon), this character can be inserted after links or other elements that generally break fonts to avoid breaking them.
 
-* <img src="https://i.imgur.com/UOB65pz.png">
+* ![](https://i.imgur.com/UOB65pz.png)
 
 * The final category does not insert emojis, but rather user-specific links. You can use these to quicklink others to your neomail/trades/auctions/shop/gallery. Empty characters are on either side of the link so you can submit as is without breaking your font.
 
-* <img src="https://i.imgur.com/m3IZTio.png">
+* ![](https://i.imgur.com/m3IZTio.png)
 
 * Any **http** links from images.neopets or pets.neopets will be embedded directly into replies. A search bar is available below the smilie section that can be utilized to find images to post.
 
-* <img src="https://i.imgur.com/SItX4J4.gif">
+* ![](https://i.imgur.com/SItX4J4.gif)
 
-* <img src="https://i.imgur.com/Qxcsdjy.png">
+* ![](https://i.imgur.com/Qxcsdjy.png)
 
 # neoboard-follow-users.js
 *by sunbathr and rawbeee*
@@ -69,19 +69,19 @@ A suite of scripts intended to enhance the neoboard experience on desktop
 
 * Followed users will have a light green byline within threads to easily differentiate them from users you are not following (if you have followed/unfollowed a user in one tab and wish to make changes in another tab, make sure the second tab has been refreshed to ensure the previous changes aren't overwritten).
 
-* <img src="https://i.imgur.com/YfJZycn.png">
+* ![](https://i.imgur.com/YfJZycn.png)
 
 * In the list of threads on each neoboard, those created by followed users will appear underlined to easily differentiate them from those you are not following.
 
-* <img src="https://i.imgur.com/CcEyyog.png">
+* ![](https://i.imgur.com/CcEyyog.png)
 
 * You may choose to edit the color of the byline and underline through the settings cog
 
-* <img src="https://i.imgur.com/EWCKLcN.png">
+* ![](https://i.imgur.com/EWCKLcN.png)
 
 * You can also block users by accesing the settings cog. Enter users in a comma seperated list (Ex: user1,user2,use3,user4). Their messages and threads will not appear for you.
 
-* <img src="https://i.imgur.com/eaZpdQi.png">
+* ![](https://i.imgur.com/eaZpdQi.png)
 
 # neoboard-bookmarks.user.js
 *by sunbathr and rawbeee*
@@ -90,15 +90,15 @@ A suite of scripts intended to enhance the neoboard experience on desktop
 
 * Within each thread is a bookmark button, clicking this will add it to the collapsible menu. This button becomes an unbookmark button when you have bookmarked a thread. You may also unbookmark by clicking the X beside the thread within the collapsible menu (if you have bookmarked/unbookmarked a thread in one tab and wish to make changes in another tab, make sure the second tab has been refreshed to ensure the previous changes aren't overwritten).
 
-* <img src="https://i.imgur.com/ydv6oPT.png">
+* ![](https://i.imgur.com/ydv6oPT.png)
 
 * You may also bookmark/unbookmark specific neoboards (Avatar Chat, Pound Chat, etc) by visiting the neoboard index (where you see the entire list of neoboards) and using the add/remove buttons. These bookmarked boards will appear above the collapsible menu (the previous warning about making changes across tabs applies here as well).
 
-* <img src="https://i.imgur.com/ytLiz0F.png">
+* ![](https://i.imgur.com/ytLiz0F.png)
 
 * You may choose to edit the color scheme through the settings cog
 
-* <img src="https://i.imgur.com/y07BHLN.png">
+* ![](https://i.imgur.com/y07BHLN.png)
 
 # other recommendations
 


### PR DESCRIPTION
It seems like the scripts no longer work for Greasemonkey v4 on Firefox, namely that `match` can't use regex, and the GM_getValue and GM_setValue functions are now obselete and replaced with some promisified equivalents that are above my pay grade to fix lol.

So instead it might make more sense to link Tampermonkey for Firefox, which has a compatibility mode turned on by default that can properly run older Greasemonkey scripts.

I also converted the HTML elements to markdown syntax to make it easier to edit the file.

Anyways, thank you for working on this. It's a game changer.

![](https://images.neopets.com/battledome/opponent_pics/24.gif)